### PR TITLE
Make sure we have curl

### DIFF
--- a/scripts/linux/install-vagrant.sh
+++ b/scripts/linux/install-vagrant.sh
@@ -4,6 +4,7 @@ VERSION=$1
 
 echo "${VERSION}"
 
+sudo apt-get install -y curl
 curl -O https://releases.hashicorp.com/vagrant/${VERSION}/vagrant_${VERSION}_x86_64.deb
 sudo dpkg -i vagrant_${VERSION}_x86_64.deb
 vagrant --version


### PR DESCRIPTION
Some boxes have wget but not curl out of the box, so make sure we have curl before we try to download Vagrant.