### PR TITLE
macOS scripts for installing Vagrant, VirtualBox, and Homebrew

### DIFF
--- a/scripts/macos/install-homebrew.sh
+++ b/scripts/macos/install-homebrew.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/su - vagrant -c '/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'

--- a/scripts/macos/install-vagrant.sh
+++ b/scripts/macos/install-vagrant.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+VERSION=$1
+
+echo "${VERSION}"
+
+curl -O https://releases.hashicorp.com/vagrant/${VERSION}/vagrant_${VERSION}_x86_64.dmg
+hdiutil attach vagrant_${VERSION}_x86_64.dmg
+sudo installer -pkg /Volumes/Vagrant/vagrant.pkg -target /
+vagrant --version

--- a/scripts/macos/install-virtualbox.sh
+++ b/scripts/macos/install-virtualbox.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+VERSION=$1
+
+echo "${VERSION}"
+
+BUILD=$(curl https://download.virtualbox.org/virtualbox/${VERSION} | grep "VirtualBox-${VERSION}-[[:digit:]]\+-OSX.dmg" | cut -d'-' -f 3)
+curl -O https://download.virtualbox.org/virtualbox/${VERSION}/VirtualBox-${VERSION}-${BUILD}-OSX.dmg
+hdiutil attach VirtualBox-${VERSION}-${BUILD}-OSX.dmg
+sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target / \
+  || echo "==> ATTENTION: You must install the VirtualBox kernel extension through the GUI."
+VBoxManage --version


### PR DESCRIPTION
Here are a few scripts to get started on macOS.  Example usage:

```
    macos.vm.provision "Vagrant", type: "shell",
      path: "scripts/macos/install-vagrant.sh",
      args: "2.2.6"

    macos.vm.provision "Homebrew", type: "shell",
      path: "scripts/macos/install-homebrew.sh"

    macos.vm.provision "VirtualBox", type: "shell",
      path: "scripts/macos/install-virtualbox.sh",
      args: "6.0.14"
```