### PR TITLE
Install latest VirtualBox from FreeBSD package repository

### DIFF
--- a/scripts/freebsd/install-vbox.sh
+++ b/scripts/freebsd/install-vbox.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+sudo pkg install -y virtualbox-ose virtualbox-ose-additions virtualbox-ose-kmod
+echo 'vboxdrv_load="YES"\nvboxvs_load="YES"' | sudo tee -a /boot/loader.conf
+echo 'vboxnet_enable="YES"' | sudo tee -a /etc/rc.conf
+echo "Please reboot this machine to enable the VirtualBox kernel modules."
+sudo pw groupmod vboxusers -m vagrant


### PR DESCRIPTION
Here's a script to install VirtualBox on FreeBSD.  Tested on bento/freebsd-12 and bento/freebsd-11, but should work on any FreeBSD that has the `virtualbox-ose-*` packages.
